### PR TITLE
Downgrade gradle build tools

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0-beta3'
+        classpath 'com.android.tools.build:gradle:1.5.0'
         classpath 'org.robolectric:robolectric-gradle-plugin:1.0.1'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
Gradle build tools downgraded from 2.0.0-beta3 to 1.5.0 for bitrise compatibility test
